### PR TITLE
OpenXR - Fix crash on init

### DIFF
--- a/app/src/main/cpp/xr/engine.c
+++ b/app/src/main/cpp/xr/engine.c
@@ -55,7 +55,7 @@ void XrEngineInit(struct XrEngine* engine, void* system, const char* name, int v
     strcpy(app_info.engineName, name);
     app_info.applicationVersion = version;
     app_info.engineVersion = version;
-    app_info.apiVersion = XR_CURRENT_API_VERSION;
+    app_info.apiVersion = XR_API_VERSION_1_0;
 
     XrInstanceCreateInfo instance_info;
     memset(&instance_info, 0, sizeof(instance_info));

--- a/app/src/main/java/com/winlator/XrActivity.java
+++ b/app/src/main/java/com/winlator/XrActivity.java
@@ -2,9 +2,7 @@ package com.winlator;
 
 import android.app.Activity;
 import android.app.ActivityOptions;
-import android.content.Context;
 import android.content.Intent;
-import android.hardware.display.DisplayManager;
 import android.os.Build;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -180,7 +178,7 @@ public class XrActivity extends XServerDisplayActivity implements TextWatcher {
         }
 
         // 1. Locate the main display ID and add that to the intent
-        final int mainDisplayId = getMainDisplay(context);
+        final int mainDisplayId = Display.DEFAULT_DISPLAY;
         ActivityOptions options = ActivityOptions.makeBasic().setLaunchDisplayId(mainDisplayId);
 
         // 2. Set the flags: start in a new task and replace any existing tasks in the app stack
@@ -296,17 +294,6 @@ public class XrActivity extends XServerDisplayActivity implements TextWatcher {
 
     private static boolean getButtonClicked(boolean[] buttons, ControllerButton button) {
         return buttons[button.ordinal()] && !lastButtons[button.ordinal()];
-    }
-
-    private static int getMainDisplay(Context context) {
-        final DisplayManager displayManager =
-                (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
-        for (Display display : displayManager.getDisplays()) {
-            if (display.getDisplayId() == Display.DEFAULT_DISPLAY) {
-                return display.getDisplayId();
-            }
-        }
-        return -1;
     }
 
     private static void mapKey(ControllerButton xrButton, byte xKeycode) {


### PR DESCRIPTION
This fixes a crash of the app on Meta Quest headsets.

Note that `app/src/main/jniLibs/arm64-v8a/libopenxr_loader.so` shouldn't be there. The library should be generated by OpenXR SDK. I had to remove it locally to be able to compile the app.

Anyway, thank you for making this app truly opensource.