### PR TITLE
OpenXR - Fix 3DoF

### DIFF
--- a/app/src/main/cpp/xr/renderer.c
+++ b/app/src/main/cpp/xr/renderer.c
@@ -322,6 +322,13 @@ void XrRendererFinishFrame(struct XrEngine* engine, struct XrRenderer* renderer)
                 pose = renderer->InvertedViewPose[eye];
             }
 
+            XrVector3f pitch_axis = {1, 0, 0};
+            XrVector3f yaw_axis = {0, 1, 0};
+            XrVector3f rotation = XrQuaternionfEulerAngles(pose.orientation);
+            XrQuaternionf pitch = XrQuaternionfCreateFromVectorAngle(pitch_axis, -ToRadians(rotation.x));
+            XrQuaternionf yaw = XrQuaternionfCreateFromVectorAngle(yaw_axis, ToRadians(rotation.y));
+            pose.orientation = XrQuaternionfMultiply(pitch, yaw);
+
             memset(&projection_layer_elements[eye], 0, sizeof(XrCompositionLayerProjectionView));
             projection_layer_elements[eye].type = XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW;
             projection_layer_elements[eye].pose = pose;


### PR DESCRIPTION
The Winlator 3DoF experience (as shown here: https://www.youtube.com/watch?v=c4faL1G1St4) is actually 2DoF only.

This PR fixes that to make the 3DoF working properly.