### PR TITLE
OpenXR - Reopening fixed

### DIFF
--- a/app/src/main/java/com/winlator/XrActivity.java
+++ b/app/src/main/java/com/winlator/XrActivity.java
@@ -68,6 +68,12 @@ public class XrActivity extends XServerDisplayActivity implements TextWatcher {
     }
 
     @Override
+    public synchronized void onDestroy() {
+        super.onDestroy();
+        System.exit(0);
+    }
+
+    @Override
     public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 
     @Override


### PR DESCRIPTION
Currently if the user uses the Quest OS menu to close the app, it stays opened on the background and that prevents opening the container next time. This PR fixes that issue.