### PR TITLE
OpenXR - Workaround for graphical glitches

### DIFF
--- a/app/src/main/cpp/xr/main.c
+++ b/app/src/main/cpp/xr/main.c
@@ -85,7 +85,7 @@ JNIEXPORT jboolean JNICALL Java_com_winlator_XrActivity_beginFrame(JNIEnv *env, 
         // Set render canvas
         int mode = immersive ? RENDER_MODE_MONO_6DOF : RENDER_MODE_MONO_SCREEN;
         xr_module_renderer.ConfigFloat[CONFIG_CANVAS_DISTANCE] = 5.0f;
-        xr_module_renderer.ConfigInt[CONFIG_PASSTHROUGH] = !immersive;
+        xr_module_renderer.ConfigInt[CONFIG_PASSTHROUGH] = true;
         xr_module_renderer.ConfigInt[CONFIG_MODE] = mode;
         xr_module_renderer.ConfigInt[CONFIG_SBS] = sbs;
 


### PR DESCRIPTION
On Meta Quest 3 there are graphical glitches when using turnip driver (tested the latest one).

The glitches are less present when passthrough is enabled. That's way I want to keep passthrough enabled even in fullscreen mode. Meta Quest 2 doesn't have this issue.