### PR TITLE
Revert "Update license"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,3 @@
-GPLv3/MIT License
-
-The code added or modified in this fork is subject to the GPLv3 license.
-The code from the upstream repository is licensed under the MIT license.
-
----
-
-GPLv3 License
-
-Copyright (C) 2024 longjunyu2, lvonasek
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
----
-
 MIT License
 
 Copyright (c) 2023 BrunoSX


### PR DESCRIPTION
As the project is no longer active in the development, I want to simplify the license. The features added under GPLv3 are now covered by MIT license.